### PR TITLE
reorder script logic for persistent slave volume

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@
 * functional programming for shell scripts
 * hard-coded values should be avoided unless there is a good reason (I.e. for security)
 * tests should be in a directory named `tests`
+* install a suitable IDE formatting plugin and run it before pushing changes. I.e. On Jetbrains IDEs
+ there is Shell Script Formatter which should have be ran (with CTRL+ALT+L or CMD+OPT+L) on each
+ script 
 
 Feel free to ask any questions in issues or on this [email](mailto:support@mesoform.com).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,87 @@
 Postgres database image setup to be used with HA replication
 
 ## How to use
-See the example in docker-compose-example.yml. Run with:
+See the example in docker-compose-example.yml. 
+
+```yamlex
+version: "3.3"
+secrets:
+  db_replica_password:
+    external: true
+  db_password:
+    external: true
+services:
+  pg_master:
+    image: mesoform/postgres-ha
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    environment:
+      - PG_MASTER=true
+      - POSTGRES_USER=testuser
+      - PG_PASSWORD_FILE=/run/secrets/db_password
+      - POSTGRES_DB=testdb
+      - PG_REP_USER=testrep
+      - PG_REP_PASSWORD_FILE=/run/secrets/db_replica_password
+      - HBA_ADDRESS=10.0.0.0/8
+    ports:
+      - "5432:5432"
+    secrets:
+      - source: db_replica_password
+        uid: "70"
+        gid: "70"
+        mode: 0550
+      - source: db_password
+        uid: "70"
+        gid: "70"
+        mode: 0550
+    networks:
+      default:
+        aliases:
+          - pg_cluster
+    deploy:
+      placement:
+        constraints:
+        - node.labels.type == primary
+  pg_slave:
+    image: mesoform/postgres-ha
+    volumes:
+      - pg_replica:/var/lib/postgresql/data
+    environment:
+      - PG_SLAVE=true
+      - POSTGRES_USER=testuser
+      - PG_PASSWORD_FILE=/run/secrets/db_password
+      - POSTGRES_DB=testdb
+      - PG_REP_USER=testrep
+      - PG_REP_PASSWORD_FILE=/run/secrets/db_replica_password
+      - PG_MASTER_HOST=pg_master
+      - HBA_ADDRESS=10.0.0.0/8
+    secrets:
+      - source: db_replica_password
+        uid: "70"
+        gid: "70"
+        mode: 0550
+      - source: db_password
+        uid: "70"
+        gid: "70"
+        mode: 0550
+    networks:
+      default:
+        aliases:
+          - pg_cluster
+    deploy:
+      placement:
+        constraints:
+        - node.labels.type != primary
+networks:
+  default:
+
+volumes:
+  pg_data: {}
+  pg_replica: {}
+
+```
+
+Run with:
 
 ```shell script
 docker stack deploy -c docker-compose-example.yml test

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -6,7 +6,7 @@ secrets:
     external: true
 services:
   pg_master:
-    image: mesoform/postgres-ha
+    image: postgres-ha
     volumes:
       - pg_data:/var/lib/postgresql/data
     environment:
@@ -37,7 +37,7 @@ services:
         constraints:
         - node.labels.type == primary
   pg_slave:
-    image: mesoform/postgres-ha
+    image: postgres-ha
     volumes:
       - pg_replica:/var/lib/postgresql/data
     environment:
@@ -67,9 +67,9 @@ services:
         constraints:
         - node.labels.type != primary
 networks:
-  default:
+  default: {}
 
 volumes:
-  pg_data:
-  pg_replica:
+  pg_data: {}
+  pg_replica: {}
 

--- a/setup-master.sh
+++ b/setup-master.sh
@@ -1,12 +1,13 @@
-#!/bin/bash
+#!/bin/bash -x
 
-[[ ! ${PG_MASTER^^} = TRUE ]] && exit 0
+[[ ! ${PG_MASTER^^} == TRUE ]] && exit 0
 
 PG_REP_PASSWORD=$(cat "${PG_REP_PASSWORD_FILE}")
 
 set -e
 source /usr/local/bin/docker-entrypoint.sh
 
+echo "adding replication user \'CREATE ROLE $PG_REP_USER\'"
 docker_process_sql <<<"
   DO \$$
   BEGIN
@@ -17,11 +18,14 @@ docker_process_sql <<<"
   \$$
 "
 
-#"SELECT 1 FROM pg_roles WHERE rolname='USR_NAME'" | grep -q 1 ||
+echo "Adding replication Host-Based Authentication"
+if grep "host replication all ${HBA_ADDRESS} md5" "$PGDATA/pg_hba.conf"; then
+  echo "'host replication all ${HBA_ADDRESS} md5' already configured"
+else
+  echo "host replication all ${HBA_ADDRESS} md5" >>"$PGDATA/pg_hba.conf"
+fi
 
-echo "host replication all ${HBA_ADDRESS} md5" >> "$PGDATA/pg_hba.conf"
-
-# replication specific configuration
+echo "Adding replication specific configuration"
 {
   echo "wal_level = hot_standby"
   echo "archive_mode = on"
@@ -30,4 +34,4 @@ echo "host replication all ${HBA_ADDRESS} md5" >> "$PGDATA/pg_hba.conf"
   echo "wal_keep_segments = 32"
   echo "hot_standby = on"
   echo "synchronous_standby_names = '*'"
-} >> "$PGDATA"/postgresql.conf
+} >>"$PGDATA"/postgresql.conf

--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -1,35 +1,35 @@
-#!/bin/bash
+#!/bin/bash -x
 
-[[ ! ${PG_SLAVE^^} = TRUE ]] && exit 0
+[[ ! ${PG_SLAVE^^} == TRUE ]] && exit 0
+[[ -f ${PGDATA}/standby.signal ]] && exit 0
+
+set -e
 
 PG_REP_PASSWORD=$(cat "${PG_REP_PASSWORD_FILE}")
 
-if [ ! -s "$PGDATA/PG_VERSION" ]; then
-echo "*:*:*:$PG_REP_USER:$PG_REP_PASSWORD" > ~/.pgpass
-
+echo "*:*:*:$PG_REP_USER:$PG_REP_PASSWORD" >~/.pgpass
 chmod 0600 ~/.pgpass
 
-until ping -c 1 -W 1 "${PG_MASTER_HOST:?missing environment variable. PG_MASTER_HOST must be set}"
-    do
-        echo "Waiting for master to ping..."
-        sleep 1s
+until ping -c 1 -W 1 "${PG_MASTER_HOST:?missing environment variable. PG_MASTER_HOST must be set}"; do
+  echo "Waiting for master to ping..."
+  sleep 1s
 done
 
-until pg_basebackup -h "${PG_MASTER_HOST}" -D "${PGDATA}" -U "${PG_REP_USER}" -vP -W
-do
+until pg_basebackup -h "${PG_MASTER_HOST}" -D "${PGDATA}" -U "${PG_REP_USER}" -vP -W; do
   echo "Waiting for master to connect..."
   sleep 1s
 done
 
-echo "host replication all ${HBA_ADDRESS} md5" >> "$PGDATA/pg_hba.conf"
-
-set -e
-
 touch "${PGDATA}"/standby.signal
 
-cat > "${PGDATA}"/postgresql.conf <<EOF
+cat >"${PGDATA}"/postgresql.conf <<EOF
 primary_conninfo = 'host=$PG_MASTER_HOST port=${PG_MASTER_PORT:-5432} user=$PG_REP_USER password=$PG_REP_PASSWORD'
 EOF
 chown postgres. "${PGDATA}" -R
 chmod 700 "${PGDATA}" -R
+
+if grep "host replication all ${HBA_ADDRESS} md5" "$PGDATA/pg_hba.conf"; then
+  echo "'host replication all ${HBA_ADDRESS} md5' already configured"
+else
+  echo "host replication all ${HBA_ADDRESS} md5" >>"$PGDATA/pg_hba.conf"
 fi


### PR DESCRIPTION
reorders some of the logic to handle persistent volumes on the slave DB. Also simplifies some elements by removing redundant code.

```
(gaz@gMacBookPro)-(18:03:50):~/
$ grep image PycharmProjects/postgres-ha/docker-compose-example.yml 
    image: hello-world
    image: mesoform/postgres-ha:dev-allow-persist-vol
    image: mesoform/postgres-ha:dev-allow-persist-vol
(gaz@gMacBookPro)-(18:03:58):~/
$ docker stack rm test-pg                                           
Removing service test-pg_hello
Removing service test-pg_pg_master
Removing service test-pg_pg_slave
Removing network test-pg_database
Removing network test-pg_app
(gaz@gMacBookPro)-(18:04:07):~/
$ docker stack deploy -c PycharmProjects/postgres-ha/docker-compose-example.yml test-pg
Creating network test-pg_database
Creating network test-pg_app
Creating service test-pg_pg_master
Creating service test-pg_pg_slave
Creating service test-pg_hello
(gaz@gMacBookPro)-(18:04:21):~/
$ mv ~/Downloads/zbx_export_templates-9swarm-template.xml 
(gaz@gMacBookPro)-(18:04:27):~/
$ watch docker stack ps test-pg
(gaz@gMacBookPro)-(18:05:46):~/
$ docker service logs -tail 5 test-pg_pg_slave
test-pg_pg_slave.1.onymathvjelk@lab2    | 2020-10-04 17:05:28.678 GMT [98] LOG:  entering standby mode
test-pg_pg_slave.1.onymathvjelk@lab2    | 2020-10-04 17:05:29.008 GMT [98] LOG:  redo starts at 0/2000028
test-pg_pg_slave.1.onymathvjelk@lab2    | 2020-10-04 17:05:29.108 GMT [98] LOG:  consistent recovery state reached at 0/2000100
test-pg_pg_slave.1.onymathvjelk@lab2    | 2020-10-04 17:05:29.108 GMT [91] LOG:  database system is ready to accept read only connections
test-pg_pg_slave.1.onymathvjelk@lab2    | 2020-10-04 17:05:29.191 GMT [102] LOG:  started streaming WAL from primary at 0/3000000 on timeline 1

(gaz@gMacBookPro)-(18:07:00):~/
$ docker stack rm test-pg
Removing service test-pg_pg_master
Removing service test-pg_pg_slave
Removing network test-pg_database
Removing network test-pg_app
(gaz@gMacBookPro)-(18:07:18):~/
$ watch docker stack ps test-pg
(gaz@gMacBookPro)-(18:07:43):~/
$ docker volume ls | grep test                  
local               test-pg_pg_data
local               test-pg_pg_replica
(gaz@gMacBookPro)-(18:07:47):~/
$ docker stack deploy -c PycharmProjects/postgres-ha/docker-compose-example.yml test-pg
Creating network test-pg_app
Creating network test-pg_database
Creating service test-pg_pg_slave
Creating service test-pg_hello
Creating service test-pg_pg_master
(gaz@gMacBookPro)-(18:08:16):~/
$ watch docker stack ps test-pg
(gaz@gMacBookPro)-(18:09:05):~/
$ 
(gaz@gMacBookPro)-(18:09:06):~/
$ 
(gaz@gMacBookPro)-(18:09:07):~/
$ docker service logs --tail 5 test-pg_pg_slave                                  
test-pg_pg_slave.1.4358qujvp7k7@lab2    | 2020-10-04 17:08:35.250 GMT [26] FATAL:  could not connect to the primary server: could not translate host name "pg_master" to address: Name does not resolve
test-pg_pg_slave.1.4358qujvp7k7@lab2    | 2020-10-04 17:08:40.251 GMT [27] FATAL:  could not connect to the primary server: could not translate host name "pg_master" to address: Name does not resolve
test-pg_pg_slave.1.4358qujvp7k7@lab2    | 2020-10-04 17:08:45.250 GMT [28] FATAL:  could not connect to the primary server: could not translate host name "pg_master" to address: Name does not resolve
test-pg_pg_slave.1.4358qujvp7k7@lab2    | 2020-10-04 17:08:50.263 GMT [36] FATAL:  could not connect to the primary server: could not translate host name "pg_master" to address: Name does not resolve
test-pg_pg_slave.1.4358qujvp7k7@lab2    | 2020-10-04 17:08:55.258 GMT [37] LOG:  started streaming WAL from primary at 0/3000000 on timeline 1
```