### PR TITLE
Add apk upgrade to get latest version of packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ FROM postgres:14.10-alpine3.18
 
 RUN apk add --update iputils htop curl busybox-suid jq \
     && curl -sOL https://cronitor.io/dl/linux_amd64.tar.gz \
-    && tar xvf linux_amd64.tar.gz -C /usr/bin/
+    && tar xvf linux_amd64.tar.gz -C /usr/bin/ \
+    && apk upgrade
 
 # Copy compiled wal-g binary from builder
 COPY --from=builder /wal-g /usr/local/bin


### PR DESCRIPTION
To resolve [snyk vulnerability](https://github.com/mesoform/postgres-ha/compare/dev/pg-v14...AlexBMes:postgres-ha:patch/SEC-123/SNYK-ALPINE318-LIBXML2-6245694?expand=1), have added `apk upgrade` which updates libxml2 to a version without the vulnerability, example using a local build from this commit:
```
postgres-ha$ docker run -it --entrypoint bash postgres-ha:local 
808342cd335d:/# apk info -vv | grep libxml2
libxml2-2.11.7-r0 - XML parsing library, version 2
```