### PR TITLE
Resolve Snyk Vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ RUN apk upgrade --no-cache
 
 # Minimal runtime tools (keep attack surface small)
 RUN apk add --no-cache \
+    "libssl3>=3.5.6-r0" \
+    "libcrypto3>=3.5.6-r0" \
     iputils \
     curl \
     jq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -----------------------------
 # Builder stage
 # -----------------------------
-FROM golang:1.22-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ENV WALG_VERSION=v1.1
 ENV GOPATH=/go
@@ -13,6 +13,17 @@ RUN set -eux; \
         bash \
         build-base \
         cmake
+
+
+# Create a cmake wrapper to force compatibility with WAL-G's Brotli submodule
+RUN mv /usr/bin/cmake /usr/bin/cmake-orig \
+    && echo '#!/bin/sh' > /usr/bin/cmake \
+    && echo 'if [ "$1" = "-E" ]; then' >> /usr/bin/cmake \
+    && echo '  exec /usr/bin/cmake-orig "$@"' >> /usr/bin/cmake \
+    && echo 'else' >> /usr/bin/cmake \
+    && echo '  exec /usr/bin/cmake-orig -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "$@"' >> /usr/bin/cmake \
+    && echo 'fi' >> /usr/bin/cmake \
+    && chmod +x /usr/bin/cmake
 
 # Fetch WAL-G source
 RUN git clone https://github.com/wal-g/wal-g.git $GOPATH/src/wal-g

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR $GOPATH/src/wal-g
 RUN set -eux; \
     git checkout $WALG_VERSION; \
     \
+    # Patch vulnerable packages
+    go get golang.org/x/net@v0.54.0; \
+    \
     # Deterministic dependency resolution (modern Go approach)
     go mod download; \
     go mod tidy; \


### PR DESCRIPTION
Changes:
* Update vulnerable go net package in wal-g to resolve [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959)
* Update libcrypto versions to resolve [CVE-2026-31789](https://github.com/advisories/GHSA-j79m-9jxq-788r) 
* Image updates to allow install of later net package version
  * Update base builder image to `golang:1.26-alpine`
  * Add cmake wrapper to inject the backward-compatibility flag required to compile WAL-G's legacy brotli submodule